### PR TITLE
captcha: Disable subtraction into negatives by default

### DIFF
--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -9,6 +9,7 @@ import type { ExtendedContext } from '../typings/context';
 import { logError } from '../utils/log';
 import { lrm } from '../utils/html';
 import { telegram } from '../bot';
+import { config } from "../utils/config"
 
 // Time to answer the math question, in seconds
 const TIME_TO_ANSWER = 60;
@@ -42,26 +43,26 @@ type Challenge = {
 
 const kickOutMember = (
 	challenges: Challenge[],
-	curerntChallenge: Challenge
+	currrentChallenge: Challenge
 ): number => {
 	return (setTimeout(() => {
 		// Delete from active challenges
-		const foundChallengeIndex = challenges.indexOf(curerntChallenge);
+		const foundChallengeIndex = challenges.indexOf(currrentChallenge);
 		if (foundChallengeIndex >= 0) {
 			challenges.splice(foundChallengeIndex, 1);
 		}
 
 		// Check if user is banned already
-		const user = getUser({ id: curerntChallenge.userId });
+		const user = getUser({ id: currrentChallenge.userId });
 
 		// For each group:
-		curerntChallenge.groups.forEach((group) => {
+		currrentChallenge.groups.forEach((group) => {
 			// Kick user
 			if (group.id && !user.banned) {
 				telegram
 					.kickChatMember(
 						group.id,
-						curerntChallenge.userId,
+						currrentChallenge.userId,
 						Date.now() / 1000 + BAN_DURATION
 					)
 					.catch(catchError);
@@ -84,6 +85,15 @@ const createMath = (): { answer: number; question: string } => {
 	do {
 		a = pick(numbers);
 		b = pick(numbers);
+
+		if (config.plugins?.captcha?.negativeSubstractionCase) {
+			// To avoid negative substraction case
+			if (b > a) {
+				const c = a
+				a = b
+				b = c
+			}
+		}
 		op = pick(Object.keys(calc)) as keyof typeof calc;
 		result = calc[op](a, b);
 	} while (result === 0);

--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -3,7 +3,7 @@
 // Description:
 //   Adds a simple captcha to the bot to kick spam bots on join.
 //   Configure `config.pluginSettings.captcha.negativeResults: true` in bot config file to enable harder substraction case
-//     with negatives results, disabled by default as it can confuse people that don't realize they have to write a - symbol
+//     with negative results, disabled by default as it can confuse people that don't realize they have to write a - symbol
 
 import { getUser, verifyCaptcha } from '../stores/user';
 import { Composer } from 'telegraf';

--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -45,26 +45,26 @@ type Challenge = {
 
 const kickOutMember = (
 	challenges: Challenge[],
-	currrentChallenge: Challenge
+	currentChallenge: Challenge
 ): number => {
 	return (setTimeout(() => {
 		// Delete from active challenges
-		const foundChallengeIndex = challenges.indexOf(currrentChallenge);
+		const foundChallengeIndex = challenges.indexOf(currentChallenge);
 		if (foundChallengeIndex >= 0) {
 			challenges.splice(foundChallengeIndex, 1);
 		}
 
 		// Check if user is banned already
-		const user = getUser({ id: currrentChallenge.userId });
+		const user = getUser({ id: currentChallenge.userId });
 
 		// For each group:
-		currrentChallenge.groups.forEach((group) => {
+		currentChallenge.groups.forEach((group) => {
 			// Kick user
 			if (group.id && !user.banned) {
 				telegram
 					.kickChatMember(
 						group.id,
-						currrentChallenge.userId,
+						currentChallenge.userId,
 						Date.now() / 1000 + BAN_DURATION
 					)
 					.catch(catchError);

--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -2,7 +2,7 @@
 // Author: poeti8
 // Description:
 //   Adds a simple captcha to the bot to kick spam bots on join.
-//   Configure `config.pluginSettings.captcha.negativeResults: true` in bot config file to enable harder substraction case
+//   Configure `config.pluginSettings.captcha.negativeResults: true` in bot config file to enable harder subtraction case
 //     with negative results, disabled by default as it can confuse people that don't realize they have to write a - symbol
 
 import { getUser, verifyCaptcha } from '../stores/user';
@@ -90,7 +90,7 @@ const createMath = (): { answer: number; question: string } => {
 
 		// Default to executing the block
 		if (!config.pluginSettings?.captcha?.negativeResults) {
-			// To avoid negative substraction case
+			// To avoid negative subtraction case
 			if (b > a) {
 				const c = a
 				a = b

--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -2,6 +2,8 @@
 // Author: poeti8
 // Description:
 //   Adds a simple captcha to the bot to kick spam bots on join.
+//   Configure `config.pluginSettings.captcha.negativeResults: true` in bot config file to enable harder substraction case
+//     with negatives results, disabled by default as it can confuse people that don't realize they have to write a - symbol
 
 import { getUser, verifyCaptcha } from '../stores/user';
 import { Composer } from 'telegraf';
@@ -86,7 +88,8 @@ const createMath = (): { answer: number; question: string } => {
 		a = pick(numbers);
 		b = pick(numbers);
 
-		if (config.plugins?.captcha?.negativeSubstractionCase) {
+		// default to executing the block
+		if (!config.pluginSettings?.captcha?.negativeResults) {
 			// To avoid negative substraction case
 			if (b > a) {
 				const c = a

--- a/plugins/captcha.ts
+++ b/plugins/captcha.ts
@@ -88,7 +88,7 @@ const createMath = (): { answer: number; question: string } => {
 		a = pick(numbers);
 		b = pick(numbers);
 
-		// default to executing the block
+		// Default to executing the block
 		if (!config.pluginSettings?.captcha?.negativeResults) {
 			// To avoid negative substraction case
 			if (b > a) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"module": "CommonJS",
+		"noEmit": true,
+		"noImplicitAny": false,
+		"strict": true,
+		"target": "ES2019",
+		"esModuleInterop": true
+	}
+}


### PR DESCRIPTION
Fix typo.
Add tsconfig from main Guard repo to please VSC.

Disable negative results by default unless defined in config.