### PR TITLE
fix: allow emoji spam

### DIFF
--- a/plugins/anti-orient.ts
+++ b/plugins/anti-orient.ts
@@ -88,7 +88,12 @@ const inRange = (c: string, range: Range) => c >= range[0] && c <= range[1];
 const isOriental = (c: string) =>
 	CJK_RANGES.some(range => inRange(c, range)) || ARABIC_RANGES.some(range => inRange(c, range));
 
-const countOffendingCodepoints = (s: string) => s.split("").filter(isOriental).length + countEmojiCodepoints(s);
+const countOffendingCodepoints = (s: string) => {
+	const emoji = countEmojiCodepoints(s);
+	const oriental = s.split("").filter(isOriental).length;
+	if (oriental > 0) return emoji + oriental;
+	else return 0;
+};
 
 const ALWAYS_BAN_BELOW = 6;
 const SMOOTH_DECAY_FROM = 50;


### PR DESCRIPTION
"🔥🔥🔥🔥🔥" will no longer get banned. Emoji only count towards banable length if oriental characters are found. Not taking the "strip" approach to emojis because this method puts the threshold for ban lower when mixed oriental+emoji are used (which is common in spam messages).